### PR TITLE
allow urls to specify interval and start/end

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -240,7 +240,7 @@ func FetchData(ctx context.Context, rpc *goclient.Client, fs *firestore.Client) 
 
 	fmt.Printf("fetching from block %v to %v\n", startBlock, endBlock)
 
-	db, _ := backend.NewFirestore2(ctx, fs)
+	db, _ := backend.NewFirestore(ctx, fs)
 
 	// load tokens into the cache
 	_, err = db.GetTokens(ctx)

--- a/main.go
+++ b/main.go
@@ -247,7 +247,7 @@ func getPairs(w http.ResponseWriter, r *http.Request) error {
 
 func getTotals(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
-	// RFC3339: "2006-01-02T15:04:05Z"
+
 	// TODO(reed): 0 < x < now is a harsh default, lots of data
 	timeStart, _ := time.Parse(time.RFC3339, r.URL.Query().Get("start_time"))
 	timeEnd, _ := time.Parse(time.RFC3339, r.URL.Query().Get("end_time"))
@@ -269,11 +269,16 @@ func getTotals(w http.ResponseWriter, r *http.Request) error {
 }
 
 func getPairBuckets(w http.ResponseWriter, r *http.Request) error {
-	// TODO query parameters for times, interval
 	ctx := r.Context()
-	timeStart := time.Now().AddDate(0, 0, -1)
-	timeEnd := time.Now()
-	interval := time.Duration(0)
+
+	// TODO(reed): 0 < x < now is a harsh default, lots of data
+	timeStart, _ := time.Parse(time.RFC3339, r.URL.Query().Get("start_time"))
+	timeEnd, _ := time.Parse(time.RFC3339, r.URL.Query().Get("end_time"))
+	if timeEnd.IsZero() {
+		timeEnd = time.Now() // default to latest
+	}
+	interval, _ := time.ParseDuration(r.URL.Query().Get("interval"))
+	// TODO we should limit interval to 1h or 24h only, default 24h?
 	symbol := chi.URLParam(r, "pair")
 
 	pairs, err := db.GetPairBuckets(ctx, symbol, timeStart, timeEnd, interval)
@@ -290,9 +295,15 @@ func getPairBuckets(w http.ResponseWriter, r *http.Request) error {
 func getTokenBuckets(w http.ResponseWriter, r *http.Request) error {
 	// TODO query parameters for times, interval
 	ctx := r.Context()
-	timeStart := time.Now().AddDate(0, 0, -1)
-	timeEnd := time.Now()
-	interval := time.Duration(0)
+
+	// TODO(reed): 0 < x < now is a harsh default, lots of data
+	timeStart, _ := time.Parse(time.RFC3339, r.URL.Query().Get("start_time"))
+	timeEnd, _ := time.Parse(time.RFC3339, r.URL.Query().Get("end_time"))
+	if timeEnd.IsZero() {
+		timeEnd = time.Now() // default to latest
+	}
+	interval, _ := time.ParseDuration(r.URL.Query().Get("interval"))
+	// TODO we should limit interval to 1h or 24h only, default 24h?
 	symbol := chi.URLParam(r, "symbol")
 
 	tokens, err := db.GetTokenBuckets(ctx, symbol, timeStart, timeEnd, interval)


### PR DESCRIPTION
hook up to backend too, it's a bit clunky but it'll do in a pinch. these
results get cached at the next level at interval specified. this works for
the totals, token and pair buckets endpoints.

TODO some decisions over minutiae like do we want price / liquidity at
beginning of window or end of window (time is currently beginning of window).
the first window is weird if we do beginning of window (it's 0) but it
otherwise makes more sense imo, but I did last for now, either way it's a view
of the windows at about the same time (just shifted up one).

TODO probably need to add in better guards around intervals / times we allow.

example usage:

```sh
$ curl localhost:8080/tokens/0xcC237fa0A4B80bA47992d102352572Db7b96A6B5/buckets\?interval\=24h\&start_time\=2020-09-13T21:00:00Z | jq .
```